### PR TITLE
Revert "ci: skip explicit rustfmt and clippy installs"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,5 +56,8 @@ jobs:
         working-directory: frontend
         run: pnpm install --frozen-lockfile
 
+      - name: Install Rust linting dependencies
+        run: rustup component add rustfmt clippy
+
       - name: Run pre-commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1


### PR DESCRIPTION
This reverts commit 8e38ca125bb02d54c357926af90c612d1f09d481.