### PR TITLE
fix(deps): downgrade utoipa-swagger-ui to 9.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3266,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "9.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29519b3c485df6b13f4478ac909a491387e9ef70204487c3b64b53749aec0be"
+checksum = "161166ec520c50144922a625d8bc4925cc801b2dda958ab69878527c0e5c5d61"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3938,16 +3938,18 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
+ "displaydoc",
  "flate2",
  "indexmap",
  "memchr",
+ "thiserror 2.0.12",
  "zopfli",
 ]
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,5 +15,5 @@ tracing = "=0.1.41"
 tracing-subscriber = { version = "=0.3.19", features = ["json"] }
 ulid = { version = "=1.2.1", features = ["serde"] }
 utoipa = { version = "=5.3.1", features = ["ulid", "chrono", "axum_extras"] }
-utoipa-swagger-ui = { version = "=9.0.1", features = ["axum"] }
+utoipa-swagger-ui = { version = "=9.0.0", features = ["axum"] }
 utoipauto = "=0.2.0"


### PR DESCRIPTION
Transitive dependency `zip` is broken on 9.0.1.

    Command failed: cargo update --config net.git-fetch-with-cli=true --manifest-path lib/Cargo.toml
        Updating crates.io index
    error: failed to select a version for the requirement `zip = "^2.6"`
      version 2.6.0 is yanked
      version 2.6.1 is yanked
    location searched: crates.io index
    required by package `utoipa-swagger-ui v9.0.1`
        ... which satisfies dependency `utoipa-swagger-ui = "=9.0.1"` of package `radiojournal-api v0.4.4 (/tmp/renovate/repos/github/fluxth/radiojournal/api)`